### PR TITLE
better console.info banner

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -1,10 +1,10 @@
 //@ts-check
-console.info("-----------------------------------");
-console.info("[BOX CRITTERS TEXTURE PACK MANAGER]");
-console.info("A chrome extention created by\nTumbleGamer");
-console.info("-----------------------------------");
-
-
+console.info(
+`-----------------------------------
+[BOX CRITTERS TEXTURE PACK MANAGER]
+A chrome extention created by TumbleGamer
+-----------------------------------`
+);
 
 var browser = browser || chrome || msBrowser;
 


### PR DESCRIPTION
uses one console.info with line breaks instead of 4